### PR TITLE
Guard media import against loading before project session is ready

### DIFF
--- a/desktop/src/App.tsx
+++ b/desktop/src/App.tsx
@@ -317,6 +317,10 @@ function Editor({
   // ── media import ─────────────────────────────────────────────────────────
   const importPaths = useCallback(
     async (paths: string[]) => {
+      if (!loaded) {
+        setError("Project is still loading, try again in a moment.");
+        return;
+      }
       setBusy(true);
       setError(null);
       for (const path of paths) {
@@ -347,7 +351,7 @@ function Editor({
       }
       setBusy(false);
     },
-    [dispatch, session.path],
+    [dispatch, session.path, loaded],
   );
 
   // Artwork for everything already in the project: a reopened project should


### PR DESCRIPTION
## Summary
- Dragging/importing a file right after opening or creating a project could race with the async `editor_open()` call: the OS drop listener in `App.tsx` is registered on mount regardless of session state, so `importPaths` could dispatch `addMedia` before the Rust `EditorState` session was populated.
- This surfaced as `with_session()` in `editor_api.rs` returning `"no project is open"` — a confusing failure right after a successful project open, with no indication of what went wrong.
- `importPaths` now bails early with a clear message ("Project is still loading, try again in a moment.") when `loaded` is still false, instead of dispatching into a session that isn't there yet.

## Test plan
- [x] `npm run app` from `desktop/`, create a project, immediately drag a video file onto the window before the timeline finishes rendering — sees the new message instead of the silent IPC/session error.
- [x] Normal import (after project fully loads) still works.