### PR TITLE
Treat a track-less project manifest as empty, not corrupt

### DIFF
--- a/engine/crates/wolfcut-project/src/doc.rs
+++ b/engine/crates/wolfcut-project/src/doc.rs
@@ -239,9 +239,18 @@ pub fn from_document(document: &Value) -> Option<Project> {
         }
     }
     if timelines.is_empty() {
-        let tracks = read_tracks(document.get("tracks"));
+        let mut tracks = read_tracks(document.get("tracks"));
         if tracks.is_empty() {
-            return None;
+            // A project manifest with no tracks yet (e.g. created but never
+            // edited before the app quit) is still a valid, empty project —
+            // not a corrupt document. Give it one so it opens instead of
+            // being rejected outright.
+            tracks.push(Track {
+                id: "track-1".to_owned(),
+                name: "Track 1".to_owned(),
+                visible: true,
+                muted: false,
+            });
         }
         let clips = read_clips(document.get("clips"), &tracks, &media);
         timelines.push(Timeline {


### PR DESCRIPTION
## Summary
- `from_document()` in `wolfcut-project/src/doc.rs` returned `None` whenever a `wolfcut.json` had no usable `tracks` (neither in `timelines[].tracks` nor the flat `tracks` fallback).
- `editor_open()` (`editor_api.rs`) surfaces that as `"{path} holds a document this build cannot read"` — which also fires for a project that was created (so its manifest only has `name`/`video`) but closed before the first edit was ever saved. That's a legitimate empty project, not a corrupt file, and the error gives no way to recover it short of hand-editing the JSON.
- `from_document()` now seeds one default track when none is found, instead of rejecting the whole document.

## Test plan
- [x] Created a project via the launch screen, quit before adding any media/clip, reopened it: previously failed with "holds a document this build cannot read"; now opens with an empty track ready to use.
- [x] A manifest with existing tracks/clips still loads them unchanged (default-track path isn't hit).