### PR TITLE
Make WolfCut work on Arch: native packaging, and a video preview that plays

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,21 @@ The repository is a flake. `nix run github:jub0t/WolfCut` starts the editor
 with ffmpeg and whisper wired in; `nix develop` opens a shell with everything
 `npm run app` needs.
 
+### Arch Linux
+
+`packaging/arch/PKGBUILD` builds WolfCut against the system WebKitGTK, Wayland
+and Mesa:
+
+```sh
+cd packaging/arch && makepkg -si
+```
+
+Prefer this over the AppImage on Arch and other rolling distros. The AppImage
+carries its Ubuntu 22.04 builder's `libwayland-client`, which is older than the
+Mesa it ends up talking to; EGL display creation then fails and the editor
+opens as an empty window. `ffmpeg` comes from the repos, and `whisper.cpp` is
+an optional dependency for transcription.
+
 ## Contribution
 
 > [!IMPORTANT]

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -10,6 +10,7 @@
 pub mod export;
 mod editor_api;
 mod jobs;
+mod media_server;
 mod playback;
 mod projects;
 mod templates;
@@ -155,6 +156,24 @@ pub(crate) fn grant_asset(app: &tauri::AppHandle, path: &str) {
     if let Err(error) = app.asset_protocol_scope().allow_file(path) {
         eprintln!("wolfcut: could not scope {path}: {error}");
     }
+    // The loopback media server answers only for paths admitted here, so the
+    // two scopes stay the same set.
+    if let Some(server) = app.try_state::<Option<media_server::MediaServer>>() {
+        if let Some(server) = server.inner() {
+            server.allow(path);
+        }
+    }
+}
+
+/// Where the preview should fetch media from.
+///
+/// `None` on the platforms whose webview plays the asset protocol correctly;
+/// the webview then keeps using `convertFileSrc`.
+#[tauri::command]
+fn media_endpoint(
+    server: tauri::State<'_, Option<media_server::MediaServer>>,
+) -> Option<media_server::Endpoint> {
+    server.inner().as_ref().map(|server| server.endpoint())
 }
 
 /// The version of the app the UI is talking to. Also a liveness check on the
@@ -861,6 +880,9 @@ pub fn run() {
             // the resource directory needs the app to exist.
             use tauri::Manager;
             use_bundled_ffmpeg(app);
+            // Linux only, and a None here just means the preview falls back to
+            // the asset protocol - see media_server for why it cannot.
+            app.manage(media_server::start());
             app.manage(playback::Playback::start(app.handle().clone()));
             app.manage(ExportState(std::sync::Arc::new(jobs::SingleFlight::new())));
             app.manage(transcribe::DownloadState(std::sync::Arc::new(
@@ -882,6 +904,7 @@ pub fn run() {
         .invoke_handler(tauri::generate_handler![
             probe_media,
             engine_version,
+            media_endpoint,
             read_media_bytes,
             extract_peaks,
             audio_set_clips,

--- a/desktop/src-tauri/src/media_server.rs
+++ b/desktop/src-tauri/src/media_server.rs
@@ -1,0 +1,348 @@
+//! A loopback HTTP server for preview media, for Linux only.
+//!
+//! WebKitGTK cannot play `<video>` from a custom URI scheme. It hands the URL
+//! straight to GStreamer, which has no source element for `asset://`, so the
+//! media fails to load before `webkitwebsrc` ever runs - the element reports
+//! `MEDIA_ERR_SRC_NOT_SUPPORTED` and the preview stays black while audio,
+//! which the engine decodes itself, plays on. Registering the scheme as
+//! CORS-enabled and secure does not help; the same file plays immediately
+//! over `file://` or `http://`.
+//!
+//! So on Linux the preview asks for media over `http://127.0.0.1`, and the
+//! asset protocol keeps serving everything else - stills and artwork are
+//! `<img>`, which has never had the problem. macOS and Windows do not start
+//! this server at all.
+//!
+//! The scope discipline from `grant_asset` carries over: the server answers
+//! for a path only after that path was admitted, and only with the token
+//! minted at startup, so another process on the machine cannot read a user's
+//! media by guessing the port.
+
+use std::collections::HashSet;
+use std::io::{BufRead, BufReader, Read, Seek, SeekFrom, Write};
+use std::net::{Ipv4Addr, TcpListener, TcpStream};
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex};
+
+/// How much of a file is moved per write while streaming a response.
+const CHUNK: usize = 64 * 1024;
+
+/// The loopback media server: a port, a token, and the set of files it will
+/// serve.
+pub(crate) struct MediaServer {
+    port: u16,
+    token: String,
+    allowed: Arc<Mutex<HashSet<PathBuf>>>,
+}
+
+/// What the webview needs to build a media URL. `None` on platforms whose
+/// webview plays the asset protocol correctly.
+#[derive(serde::Serialize)]
+pub(crate) struct Endpoint {
+    /// The loopback port the server accepted on.
+    pub port: u16,
+    /// The per-run token every request must carry.
+    pub token: String,
+}
+
+impl MediaServer {
+    /// Starts the server on a free loopback port.
+    fn start() -> std::io::Result<Self> {
+        let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0))?;
+        let port = listener.local_addr()?.port();
+        let token = random_token();
+        let allowed: Arc<Mutex<HashSet<PathBuf>>> = Arc::new(Mutex::new(HashSet::new()));
+
+        let serving = Arc::clone(&allowed);
+        let expected = token.clone();
+        std::thread::spawn(move || {
+            for stream in listener.incoming().flatten() {
+                let allowed = Arc::clone(&serving);
+                let expected = expected.clone();
+                // A thread per connection: WebKit opens a handful for
+                // seeking, and a blocking handler is far less machinery than
+                // pulling an async runtime in for three routes.
+                std::thread::spawn(move || {
+                    let _ = handle(stream, &allowed, &expected);
+                });
+            }
+        });
+
+        Ok(Self {
+            port,
+            token,
+            allowed,
+        })
+    }
+
+    /// What the webview should talk to.
+    pub(crate) fn endpoint(&self) -> Endpoint {
+        Endpoint {
+            port: self.port,
+            token: self.token.clone(),
+        }
+    }
+
+    /// Admits one file, mirroring the asset protocol scope.
+    pub(crate) fn allow(&self, path: &str) {
+        let resolved = std::fs::canonicalize(path).unwrap_or_else(|_| PathBuf::from(path));
+        if let Ok(mut allowed) = self.allowed.lock() {
+            allowed.insert(resolved);
+        }
+    }
+}
+
+/// Starts the server where the webview needs it, or explains why it did not.
+///
+/// A failure here is not fatal: the preview falls back to the asset protocol,
+/// which is what the other platforms use anyway.
+pub(crate) fn start() -> Option<MediaServer> {
+    if !cfg!(target_os = "linux") {
+        return None;
+    }
+    match MediaServer::start() {
+        Ok(server) => Some(server),
+        Err(error) => {
+            eprintln!("wolfcut: preview media server unavailable: {error}");
+            None
+        }
+    }
+}
+
+/// Answers one request.
+fn handle(
+    mut stream: TcpStream,
+    allowed: &Mutex<HashSet<PathBuf>>,
+    expected: &str,
+) -> std::io::Result<()> {
+    let mut reader = BufReader::new(stream.try_clone()?);
+
+    let mut request = String::new();
+    reader.read_line(&mut request)?;
+    let target = match request.split_whitespace().nth(1) {
+        Some(target) => target.to_owned(),
+        None => return refuse(&mut stream, 400, "Bad Request"),
+    };
+
+    // Only the Range header matters; the rest is read to keep the client from
+    // blocking on an unread request body.
+    let mut range = None;
+    loop {
+        let mut line = String::new();
+        if reader.read_line(&mut line)? == 0 || line == "\r\n" || line == "\n" {
+            break;
+        }
+        if let Some(value) = line.strip_prefix("Range:").or(line.strip_prefix("range:")) {
+            range = Some(value.trim().to_owned());
+        }
+    }
+
+    let (path, token) = match parse_target(&target) {
+        Some(parsed) => parsed,
+        None => return refuse(&mut stream, 400, "Bad Request"),
+    };
+
+    if token != expected {
+        return refuse(&mut stream, 403, "Forbidden");
+    }
+
+    let resolved = match std::fs::canonicalize(&path) {
+        Ok(resolved) => resolved,
+        Err(_) => return refuse(&mut stream, 404, "Not Found"),
+    };
+
+    let admitted = allowed
+        .lock()
+        .map(|allowed| allowed.contains(&resolved))
+        .unwrap_or(false);
+    if !admitted {
+        return refuse(&mut stream, 403, "Forbidden");
+    }
+
+    send(&mut stream, &resolved, range.as_deref())
+}
+
+/// Pulls the media path and the token out of `/media?t=...&path=...`.
+fn parse_target(target: &str) -> Option<(String, String)> {
+    let query = target.split_once('?')?.1;
+    let mut path = None;
+    let mut token = None;
+    for pair in query.split('&') {
+        let (key, value) = pair.split_once('=')?;
+        match key {
+            "path" => path = Some(percent_decode(value)),
+            "t" => token = Some(percent_decode(value)),
+            _ => {}
+        }
+    }
+    Some((path?, token?))
+}
+
+/// Decodes the percent-escapes `encodeURIComponent` produces.
+fn percent_decode(input: &str) -> String {
+    let bytes = input.as_bytes();
+    let mut out = Vec::with_capacity(bytes.len());
+    let mut index = 0;
+    while index < bytes.len() {
+        if bytes[index] == b'%' && index + 2 < bytes.len() {
+            let hex = std::str::from_utf8(&bytes[index + 1..index + 3]).ok();
+            if let Some(byte) = hex.and_then(|hex| u8::from_str_radix(hex, 16).ok()) {
+                out.push(byte);
+                index += 3;
+                continue;
+            }
+        }
+        out.push(bytes[index]);
+        index += 1;
+    }
+    String::from_utf8_lossy(&out).into_owned()
+}
+
+/// Writes the file, whole or as the requested range.
+fn send(stream: &mut TcpStream, path: &Path, range: Option<&str>) -> std::io::Result<()> {
+    let mut file = std::fs::File::open(path)?;
+    let length = file.metadata()?.len();
+    let kind = content_type(path);
+
+    let (start, end) = match range.and_then(|range| parse_range(range, length)) {
+        Some(bounds) => bounds,
+        None => (0, length.saturating_sub(1)),
+    };
+
+    if length == 0 || start > end || start >= length {
+        let head = format!(
+            "HTTP/1.1 416 Range Not Satisfiable\r\nContent-Range: bytes */{length}\r\n\
+             Content-Length: 0\r\nConnection: close\r\n\r\n"
+        );
+        return stream.write_all(head.as_bytes());
+    }
+
+    let count = end - start + 1;
+    let head = if range.is_some() {
+        format!(
+            "HTTP/1.1 206 Partial Content\r\nContent-Type: {kind}\r\n\
+             Content-Length: {count}\r\nAccept-Ranges: bytes\r\n\
+             Content-Range: bytes {start}-{end}/{length}\r\nConnection: close\r\n\r\n"
+        )
+    } else {
+        format!(
+            "HTTP/1.1 200 OK\r\nContent-Type: {kind}\r\nContent-Length: {count}\r\n\
+             Accept-Ranges: bytes\r\nConnection: close\r\n\r\n"
+        )
+    };
+    stream.write_all(head.as_bytes())?;
+
+    file.seek(SeekFrom::Start(start))?;
+    let mut remaining = count;
+    let mut buffer = vec![0u8; CHUNK];
+    while remaining > 0 {
+        let want = remaining.min(CHUNK as u64) as usize;
+        let read = file.read(&mut buffer[..want])?;
+        if read == 0 {
+            break;
+        }
+        // A seek that moved on leaves the old response half-written; the
+        // client hanging up is normal, not an error worth reporting.
+        if stream.write_all(&buffer[..read]).is_err() {
+            return Ok(());
+        }
+        remaining -= read as u64;
+    }
+    Ok(())
+}
+
+/// Reads `bytes=start-end`, `bytes=start-` and `bytes=-suffix`.
+fn parse_range(header: &str, length: u64) -> Option<(u64, u64)> {
+    let spec = header.strip_prefix("bytes=")?.split(',').next()?.trim();
+    let (start, end) = spec.split_once('-')?;
+    if start.is_empty() {
+        let suffix: u64 = end.parse().ok()?;
+        let suffix = suffix.min(length);
+        return Some((length.saturating_sub(suffix), length.saturating_sub(1)));
+    }
+    let start: u64 = start.parse().ok()?;
+    let end = if end.is_empty() {
+        length.saturating_sub(1)
+    } else {
+        end.parse::<u64>().ok()?.min(length.saturating_sub(1))
+    };
+    Some((start, end))
+}
+
+/// A media type the webview will accept, guessed from the extension.
+fn content_type(path: &Path) -> &'static str {
+    let extension = path
+        .extension()
+        .and_then(|extension| extension.to_str())
+        .unwrap_or_default()
+        .to_ascii_lowercase();
+    match extension.as_str() {
+        "mp4" | "m4v" => "video/mp4",
+        "mov" | "qt" => "video/quicktime",
+        "webm" => "video/webm",
+        "mkv" => "video/x-matroska",
+        "avi" => "video/x-msvideo",
+        "mpg" | "mpeg" => "video/mpeg",
+        "m4a" => "audio/mp4",
+        "mp3" => "audio/mpeg",
+        "wav" => "audio/wav",
+        "aac" => "audio/aac",
+        "flac" => "audio/flac",
+        "ogg" | "oga" => "audio/ogg",
+        "opus" => "audio/opus",
+        _ => "application/octet-stream",
+    }
+}
+
+/// A bodyless refusal.
+fn refuse(stream: &mut TcpStream, code: u16, reason: &str) -> std::io::Result<()> {
+    let head =
+        format!("HTTP/1.1 {code} {reason}\r\nContent-Length: 0\r\nConnection: close\r\n\r\n");
+    stream.write_all(head.as_bytes())
+}
+
+/// A per-run token, from the process-random seed `RandomState` already keeps.
+fn random_token() -> String {
+    use std::collections::hash_map::RandomState;
+    use std::hash::{BuildHasher, Hasher};
+
+    let mut token = String::with_capacity(32);
+    for salt in 0..2u64 {
+        let mut hasher = RandomState::new().build_hasher();
+        hasher.write_u64(salt);
+        hasher.write_u32(std::process::id());
+        token.push_str(&format!("{:016x}", hasher.finish()));
+    }
+    token
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ranges_cover_the_forms_webkit_sends() {
+        assert_eq!(parse_range("bytes=0-", 100), Some((0, 99)));
+        assert_eq!(parse_range("bytes=10-19", 100), Some((10, 19)));
+        assert_eq!(parse_range("bytes=-20", 100), Some((80, 99)));
+        // An end past the file is clamped rather than refused.
+        assert_eq!(parse_range("bytes=90-200", 100), Some((90, 99)));
+        assert_eq!(parse_range("chunks=0-", 100), None);
+    }
+
+    #[test]
+    fn target_yields_path_and_token() {
+        let target = "/media?t=abc&path=%2Ftmp%2Fa%20b.mov";
+        assert_eq!(
+            parse_target(target),
+            Some(("/tmp/a b.mov".to_owned(), "abc".to_owned()))
+        );
+        assert_eq!(parse_target("/media"), None);
+    }
+
+    #[test]
+    fn token_is_not_constant() {
+        assert_ne!(random_token(), random_token());
+        assert_eq!(random_token().len(), 32);
+    }
+}

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -24,7 +24,7 @@
       }
     ],
     "security": {
-      "csp": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' asset: http://asset.localhost blob: data:; media-src 'self' asset: http://asset.localhost blob:; font-src 'self' data:; connect-src ipc: http://ipc.localhost 'self'",
+      "csp": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' asset: http://asset.localhost blob: data:; media-src 'self' asset: http://asset.localhost blob: http://127.0.0.1:*; font-src 'self' data:; connect-src ipc: http://ipc.localhost 'self'",
       "devCsp": "default-src * 'unsafe-inline' 'unsafe-eval' blob: data: asset: http://asset.localhost ws: wss: ipc: http://ipc.localhost",
       "assetProtocol": {
         "enable": true,

--- a/desktop/src/components/Preview.tsx
+++ b/desktop/src/components/Preview.tsx
@@ -8,6 +8,8 @@ import {
 } from "react";
 import { convertFileSrc } from "@tauri-apps/api/core";
 
+import { mediaSrc } from "../lib/media";
+
 import { buildPreviewLook, type AppliedEffect, type CanvasOp } from "../lib/effects";
 import type { PreviewSource, TextOverlay } from "../lib/monitor";
 import { timecode } from "../lib/time";
@@ -438,7 +440,7 @@ export function Preview({
 
     if (loadedClip.current !== source.clipId) {
       loadedClip.current = source.clipId;
-      element.src = convertFileSrc(source.path);
+      element.src = mediaSrc(source.path);
       element.load();
     }
   }, [source, hasFrame]);
@@ -1072,7 +1074,7 @@ function GhostVideo({
   useEffect(() => {
     const media = element.current;
     if (!media) return;
-    media.src = convertFileSrc(ghost.path);
+    media.src = mediaSrc(ghost.path);
     media.load();
     // Mount effect only: the sync effect below lands the position.
      

--- a/desktop/src/lib/engine.ts
+++ b/desktop/src/lib/engine.ts
@@ -51,6 +51,24 @@ export async function probeMedia(path: string): Promise<MediaSummary> {
   return invoke<MediaSummary>("probe_media", { path });
 }
 
+/** Where the preview fetches media, when the asset protocol will not serve it. */
+export interface MediaEndpoint {
+  /** The loopback port the host's media server accepted on. */
+  port: number;
+  /** The per-run token every request must carry. */
+  token: string;
+}
+
+/**
+ * Asks the host where preview media should be fetched from.
+ *
+ * Null everywhere the webview plays the asset protocol correctly, which is
+ * every platform but Linux - see `src-tauri/src/media_server.rs`.
+ */
+export async function mediaEndpoint(): Promise<MediaEndpoint | null> {
+  return invoke<MediaEndpoint | null>("media_endpoint");
+}
+
 /** A probe result in the shape `addMedia` and `fillSlot` take. */
 export function newMediaFromSummary(summary: MediaSummary): NewMedia {
   return {

--- a/desktop/src/lib/media.ts
+++ b/desktop/src/lib/media.ts
@@ -1,0 +1,37 @@
+import { convertFileSrc } from "@tauri-apps/api/core";
+
+import { mediaEndpoint } from "./engine";
+
+/**
+ * Where preview media comes from.
+ *
+ * Everywhere but Linux that is the asset protocol, same as any other file the
+ * webview reads. WebKitGTK cannot play `<video>` from a custom URI scheme - it
+ * hands the URL to GStreamer, which has no source for `asset://`, so the
+ * element fails with MEDIA_ERR_SRC_NOT_SUPPORTED before a byte is read. There
+ * the host runs a loopback HTTP server instead and this module addresses it.
+ *
+ * `initMediaSource` resolves before the first render, so building a URL stays
+ * synchronous at every call site.
+ */
+
+let base: string | null = null;
+
+/** Asks the host where media should be fetched from. Safe to call twice. */
+export async function initMediaSource(): Promise<void> {
+  try {
+    const endpoint = await mediaEndpoint();
+    base = endpoint
+      ? `http://127.0.0.1:${endpoint.port}/media?t=${encodeURIComponent(endpoint.token)}&path=`
+      : null;
+  } catch {
+    // An older host, or a server that could not bind: the asset protocol is
+    // still correct everywhere it works, so fall back rather than fail.
+    base = null;
+  }
+}
+
+/** A URL the `<video>` element can actually load. */
+export function mediaSrc(path: string): string {
+  return base ? base + encodeURIComponent(path) : convertFileSrc(path);
+}

--- a/desktop/src/main.tsx
+++ b/desktop/src/main.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import ReactDOM from "react-dom/client";
 
 import { App } from "./App";
+import { initMediaSource } from "./lib/media";
 import "./styles.css";
 
 /*
@@ -25,8 +26,12 @@ if (!root) {
   throw new Error("index.html is missing #root");
 }
 
-ReactDOM.createRoot(root).render(
-  <React.StrictMode>
-    <App />
-  </React.StrictMode>,
-);
+// Resolved before the first render so that `mediaSrc` is synchronous at every
+// call site; a failure inside it already falls back to the asset protocol.
+initMediaSource().then(() => {
+  ReactDOM.createRoot(root).render(
+    <React.StrictMode>
+      <App />
+    </React.StrictMode>,
+  );
+});

--- a/packaging/arch/.gitignore
+++ b/packaging/arch/.gitignore
@@ -1,0 +1,8 @@
+# makepkg builds in the directory holding the PKGBUILD, so a `makepkg -si`
+# from here leaves its working tree, its bare clone of this repository and the
+# built package behind. None of that belongs in the repository.
+/src/
+/pkg/
+/wolfcut/
+/*.pkg.tar.*
+/*.log

--- a/packaging/arch/PKGBUILD
+++ b/packaging/arch/PKGBUILD
@@ -1,0 +1,99 @@
+# Maintainer: TinyBrickBoy <tbb@onthepixel.net>
+
+# Arch packaging (see packaging/arch/README.md). A -git package rather than a
+# versioned one on purpose: every green build on main mints a new
+# v<version>-alpha.<n> tag, so pinning a release would go stale within a day.
+#
+# This builds against the system WebKitGTK, Wayland and Mesa instead of the
+# copies the AppImage carries from its Ubuntu 22.04 builder. On a rolling
+# distro that difference is the whole point: the bundled libwayland-client is
+# older than the Mesa it ends up talking to, EGL display creation fails with
+# EGL_BAD_PARAMETER, and the editor comes up as an empty window.
+
+_pkgname=wolfcut
+pkgname=wolfcut-git
+pkgver=0.2.0.alpha.10
+pkgrel=1
+pkgdesc="Free and open source video editor"
+arch=('x86_64' 'aarch64')
+url="https://github.com/jub0t/WolfCut"
+license=('MPL-2.0')
+depends=(
+  'alsa-lib'
+  'ffmpeg'
+  'gcc-libs'
+  'glib-networking'
+  'glibc'
+  'gtk3'
+  'libsoup3'
+  'openssl'
+  'webkit2gtk-4.1'
+)
+makedepends=('cargo' 'git' 'npm' 'pkgconf')
+optdepends=('whisper.cpp: local auto-captions and transcription')
+provides=("$_pkgname=$pkgver")
+conflicts=("$_pkgname")
+# makepkg's lto option appends -flto=auto to CFLAGS, which the cc crate then
+# uses for ring's C and assembly sources. The archive it produces has nothing
+# rustc's own non-LTO link step can resolve, so every ring_core_* symbol comes
+# out undefined and sherpa-onnx-sys fails to link. Cargo does its own LTO for
+# this build anyway (lto = true in profile.release), so nothing is lost.
+options=('!lto')
+source=("$_pkgname::git+$url.git")
+sha256sums=('SKIP')
+
+pkgver() {
+  cd "$srcdir/$_pkgname"
+  git describe --tags | sed 's/^v//; s/-/./g'
+}
+
+prepare() {
+  cd "$srcdir/$_pkgname/desktop"
+  npm ci
+  export RUSTUP_TOOLCHAIN=stable
+  cargo fetch --locked --manifest-path src-tauri/Cargo.toml
+}
+
+build() {
+  cd "$srcdir/$_pkgname/desktop"
+  export RUSTUP_TOOLCHAIN=stable
+  # The release guard in build.rs insists on a staged ffmpeg/ffprobe/whisper-cli
+  # trio, because a desktop launch has no PATH to fall back on. A distro package
+  # must not ship private copies of what the repos already provide, so it opts
+  # out here and depends on the system binaries instead - the same deal the Nix
+  # flake makes. The app looks beside itself first, then falls back to PATH.
+  export WOLFCUT_SYSTEM_TOOLS=1
+  # --no-bundle: pacman is the bundler. Everything tauri would produce here
+  # (deb, rpm, AppImage) is another distro's packaging.
+  npm run app:build -- --no-bundle
+}
+
+package() {
+  cd "$srcdir/$_pkgname"
+
+  install -Dm755 desktop/src-tauri/target/release/wolfcut-desktop \
+    "$pkgdir/usr/bin/wolfcut-desktop"
+
+  for size in 32 64 128; do
+    install -Dm644 "desktop/src-tauri/icons/${size}x${size}.png" \
+      "$pkgdir/usr/share/icons/hicolor/${size}x${size}/apps/$_pkgname.png"
+  done
+
+  install -Dm644 LICENSE "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
+  install -Dm644 THIRD_PARTY_NOTICES.md \
+    "$pkgdir/usr/share/licenses/$pkgname/THIRD_PARTY_NOTICES.md"
+
+  # Written here rather than shipped as a source file: the desktop entry has no
+  # life outside the package, and this keeps the PKGBUILD a single file for AUR.
+  install -Dm644 /dev/stdin "$pkgdir/usr/share/applications/$_pkgname.desktop" <<EOF
+[Desktop Entry]
+Type=Application
+Name=WolfCut
+Comment=$pkgdesc
+Exec=wolfcut-desktop %U
+Icon=$_pkgname
+Terminal=false
+Categories=AudioVideo;Video;AudioVideoEditing;
+StartupWMClass=wolfcut-desktop
+EOF
+}

--- a/packaging/arch/README.md
+++ b/packaging/arch/README.md
@@ -1,0 +1,31 @@
+# Arch Linux packaging
+
+`makepkg -si` from this directory builds and installs WolfCut.
+
+The package is `wolfcut-git`, not a versioned `wolfcut`. Every green build on
+`main` mints a fresh `v<version>-alpha.<n>` tag, so a pinned release would be
+stale within a day; `pkgver()` reads the newest tag out of the checkout
+instead.
+
+## Why a native package and not the AppImage
+
+The AppImage is built on Ubuntu 22.04 and carries that machine's GTK stack,
+`libwayland-client` included. On a rolling distro the system Mesa is far newer
+than that library, EGL display creation fails with `EGL_BAD_PARAMETER`, the
+WebKit web process dies, and the editor comes up as an empty window.
+
+This package links the system WebKitGTK, Wayland and Mesa, so there is no
+version skew to hit.
+
+## Bundled tools
+
+`build.rs` refuses a release build without a staged ffmpeg/ffprobe/whisper-cli
+trio, because a desktop launch has no `PATH` to fall back on. A distro package
+must not ship private copies of what the repos already provide, so the build
+sets `WOLFCUT_SYSTEM_TOOLS=1` to opt out - the same deal `flake.nix` makes -
+and depends on the system `ffmpeg`. The app looks for its tools beside the
+executable first and falls back to `PATH`.
+
+`whisper.cpp` is an `optdepends`: without it everything but transcription
+works, and Settings > Transcriber can still be pointed at a `whisper-cli`
+elsewhere.


### PR DESCRIPTION
Two changes, both about WolfCut actually working on a rolling Linux distro. The second is not Arch-specific — it affects every Linux user.

---

# 1. An Arch Linux PKGBUILD

The AppImage does not work on rolling distros. It is built on Ubuntu 22.04, and linuxdeploy bundles that machine's `libwayland-client` alongside the GTK stack; `LD_LIBRARY_PATH` then puts it ahead of the system copy. On Arch the system Mesa is far newer and EGL display creation fails, so the WebKit web process dies and **the editor opens as an empty window**.

```
$ ./WolfCut_0.2.0_amd64.AppImage
Could not create default EGL display: EGL_BAD_PARAMETER. Aborting...
```

Restoring the bundled libwayland libraries one at a time pins that message to `libwayland-client` alone:

| bundled lib restored | result |
| --- | --- |
| `libwayland-client.so.0` | `EGL_BAD_PARAMETER` |
| `libwayland-server.so.0` | fine |
| `libwayland-cursor.so.0` | fine |
| `libwayland-egl.so.1` | fine |

**Dropping the bundled libwayland is not a fix either.** With all four removed and the message silenced, a launch from the desktop menu still aborted in `WebKitWebProcess` (SIGABRT inside `libwebkit2gtk`, core dumped) while the same AppDir started fine from a shell. The bundled GTK stack does not survive contact with a rolling system, and chasing individual libraries out of it is not a strategy.

`packaging/arch/PKGBUILD` follows the deal `flake.nix` already makes: `WOLFCUT_SYSTEM_TOOLS=1` and a dependency on the system `ffmpeg`, rather than shipping private copies of what the repos already provide. `whisper.cpp` is an `optdepends`. It is a `-git` package because a green build on `main` mints a new alpha tag; a pinned version would be stale within a day.

Two things the Ubuntu CI cannot see:

- **`options=('!lto')`.** makepkg enables LTO by default and appends `-flto=auto` to `CFLAGS`, which the `cc` crate then uses for ring's C and assembly sources. The archive it produces has nothing rustc's own link step can resolve, so every `ring_core_*` symbol comes out undefined and `sherpa-onnx-sys` fails to link. Cargo does its own LTO here anyway.
- **`--no-bundle`**, because pacman is the bundler.

A `.gitignore` keeps makepkg's output — `src/`, `pkg/`, a bare clone, the built package, some 2.7 GB — out of the working tree. Found by building the package the way the README tells people to.

---

# 2. Preview media over loopback HTTP on Linux

With the app finally running, the video preview is black while its audio plays. Stills and artwork appear; only the moving picture is missing.

```
webkitmediaplayer MediaPlayerPrivateGStreamer.cpp:1554:loadingFailed:
Loading failed, error: FormatError
```

That fires 43 ms in, before playback is requested, and no `webkitwebsrc` appears in a `GST_DEBUG` trace at all — the media is rejected before a GStreamer source element exists. Audio is unaffected because the engine decodes it itself rather than through the webview, which is what makes the symptom look like a rendering bug.

It is not. `WEBKIT_DISABLE_DMABUF_RENDERER=1`, `WEBKIT_DISABLE_COMPOSITING_MODE=1`, `GDK_BACKEND=wayland` and `LIBGL_ALWAYS_SOFTWARE=1` all leave it black. The file is fine: `ffprobe` reports plain H.264 High / yuv420p / AAC, and `gst-discoverer-1.0` resolves both streams.

WebKitGTK cannot play `<video>` from a custom URI scheme. Measured against the same WebKit the app embeds, loading one H.264/AAC file three ways:

| delivery | result |
| --- | --- |
| `file://` | `canplay 576x1024` |
| custom scheme, CORS-enabled + secure, correct MIME | **`error code 4`** |
| `http://127.0.0.1` with range support | `canplay 576x1024` |

Error 4 is `MEDIA_ERR_SRC_NOT_SUPPORTED`. Registering the scheme as CORS-enabled and secure does not help, so this is not something the asset protocol can be configured out of. Known WebKitGTK limitation: tauri-apps/tauri#3725, tauri-apps/tauri#8579.

So on Linux the host runs a loopback HTTP server for preview media and the `<video>` elements address that. Stills and artwork stay on the asset protocol, which has never had the problem. macOS and Windows do not start the server at all: `media_endpoint` returns `null` and `mediaSrc` falls back to `convertFileSrc`.

**The scope discipline is preserved, not worked around.** `grant_asset` still admits one file at a time, and the server answers only for paths that went through it — the reachable set is identical to the asset protocol's, so the comment on `grant_asset` still holds. A per-run token in the URL keeps another local process from reading a user's media by guessing the port. Range requests are implemented because seeking depends on them.

Written against `std::net` rather than an HTTP crate: three routes do not justify a new dependency, and **`Cargo.lock` is untouched**. `media_endpoint` is wrapped in `lib/engine.ts` like every other command, so the IPC registry tests stay green.

---

## Verified

On Arch (kernel 7.1.6, Mesa 26.2.1, `webkit2gtk-4.1` 2.52.6, rustc 1.98):

- `makepkg` builds, `pacman -U` installs, `ldd` shows the binary resolving `libwebkit2gtk-4.1`, `libwayland-client`, `libgtk-3` and `libsoup-3.0` to `/usr/lib`
- the app runs with a live `WebKitWebProcess` out of `/usr/lib/webkit2gtk-4.1` and leaves no coredump, where the AppImage leaves one behind
- the loopback server binds, and the video preview plays — confirmed in normal use, not just at startup
- `npm run typecheck`, `npm run lint`, `npm test` (105 passed), `cargo test` and `cargo clippy --all-targets -- -D warnings` all clean; three new unit tests cover the range forms WebKit sends, the URL split, and token freshness

The two halves are independent and I am happy to split them if you would rather review them apart — GitHub is currently refusing to let me open a second pull request from this account, which is the only reason they arrived together.

Only tested on Linux. The macOS and Windows paths are unchanged by construction (the server never starts there), but a second pair of eyes on that would be welcome.
