### PR TITLE
Duplicate every selected clip from the context menu

### DIFF
--- a/engine/crates/concat/src/studio.rs
+++ b/engine/crates/concat/src/studio.rs
@@ -3758,6 +3758,39 @@ impl Studio {
 
     /// A copy of `source` laid after it. Three commands, because a clip's
     /// in-point and length are set by trims, not by placement.
+    /// Duplicate every unlocked selected clip (right-to-left by start so
+    /// neighbours do not stack). Falls back to the menu target when the
+    /// selection is empty.
+    pub fn duplicate_selected(&mut self) {
+        let mut sources: Vec<Clip> = self
+            .selection
+            .iter()
+            .filter_map(|id| self.clip(id).cloned())
+            .filter(|clip| !self.locked(&clip.track_id))
+            .collect();
+        if sources.is_empty() {
+            if let Some(id) = self.menu_target.clone() {
+                if let Some(clip) = self.clip(&id).cloned() {
+                    if !self.locked(&clip.track_id) {
+                        sources.push(clip);
+                    }
+                }
+            }
+        }
+        if sources.is_empty() {
+            return;
+        }
+        sources.sort_by(|left, right| right.start.total_cmp(&left.start));
+        let mut last = None;
+        for source in &sources {
+            self.duplicate(source);
+            last = self.selection.first().cloned();
+        }
+        if let Some(id) = last {
+            self.selection = vec![id];
+        }
+    }
+
     pub fn duplicate(&mut self, source: &Clip) {
         let end = source.start + source.duration;
         if source.kind == model::ClipKind::Text {
@@ -5947,7 +5980,7 @@ impl Studio {
         };
         match action {
             "copy" => self.clipboard = Some(clip),
-            "duplicate" => self.duplicate(&clip),
+            "duplicate" => self.duplicate_selected(),
             "paste" => {
                 if let Some(held) = self.clipboard.clone() {
                     let mut source = held;


### PR DESCRIPTION
## Summary
Previously **Duplicate** only copied the menu-target clip. Multi-select now duplicates each unlocked selected clip (right-to-left by start so neighbours do not stack), and falls back to the menu target when the selection is empty.

## Changes
- Add `Studio::duplicate_selected`
- Wire the context-menu / clip `duplicate` action to it

## Test plan
- [ ] Select one clip, Duplicate: still places a copy after it
- [ ] Multi-select unlocked clips, Duplicate: each is copied without stacking
- [ ] Locked lane clips in the selection are skipped
- [ ] Empty selection with a menu target still duplicates that clip