### PR TITLE
feat: media bin sorting — View menu, auto-grouping, header dropdowns

### DIFF
--- a/engine/crates/concat/src/lib.rs
+++ b/engine/crates/concat/src/lib.rs
@@ -1077,6 +1077,9 @@ pub fn run() -> Result<(), slint::PlatformError> {
                         "undo" => state.undo(),
                         "redo" => state.redo(),
                         "snap" => state.snap = !state.snap,
+                        "sort-added" => state.set_media_sort(0),
+                        "sort-name" => state.set_media_sort(1),
+                        "sort-kind" => state.set_media_sort(2),
                         "zoom-in" => {
                             state.seconds_per_pixel = (state.seconds_per_pixel / 1.4).max(0.000_5)
                         }

--- a/engine/crates/concat/src/lib.rs
+++ b/engine/crates/concat/src/lib.rs
@@ -393,6 +393,11 @@ pub fn run() -> Result<(), slint::PlatformError> {
     editor.on_media_filter_changed(on_window!(|state, filter: MediaFilter| {
         state.set_media_filter(filter);
     }));
+    editor.on_media_sort_changed(on_window!(|state, index: i32| {
+        // Slint hands indices over as i32; the sort is an index into a
+        // three-entry table, so clamp negatives to the default order.
+        state.set_media_sort(index.max(0) as usize);
+    }));
     editor.on_media_select(on_window!(|state, id: i32, additive: bool| {
         state.media_select(id, additive);
     }));

--- a/engine/crates/concat/src/studio.rs
+++ b/engine/crates/concat/src/studio.rs
@@ -638,6 +638,8 @@ pub struct Studio {
     next_media_row: i32,
     media_selected: HashSet<String>,
     media_filter: MediaFilter,
+    /// 0 = Added, 1 = Name, 2 = Kind
+    media_sort: usize,
     /// Decoded art by media id, and the ids a worker is decoding for.
     pub peaks: HashMap<String, Arc<Peaks>>,
     pub thumbs: HashMap<String, slint::Image>,
@@ -1319,6 +1321,7 @@ impl Studio {
             next_media_row: 1,
             media_selected: HashSet::new(),
             media_filter: MediaFilter::All,
+            media_sort: 0,
             peaks: HashMap::new(),
             thumbs: HashMap::new(),
             strips: HashMap::new(),
@@ -2012,6 +2015,10 @@ impl Studio {
 
     pub fn set_media_filter(&mut self, filter: MediaFilter) {
         self.media_filter = filter;
+    }
+
+    pub fn set_media_sort(&mut self, sort: usize) {
+        self.media_sort = sort.min(2);
     }
 
     pub fn media_select(&mut self, row: i32, additive: bool) {
@@ -6368,16 +6375,21 @@ impl Studio {
             .filter(|item| Self::shows(filter, item.kind))
             .collect();
 
-        visible.sort_by(|a, b| {
-            let rank = |kind: model::MediaKind| match kind {
-                model::MediaKind::Video => 0,
-                model::MediaKind::Audio => 1,
-                model::MediaKind::Image => 2,
-            };
-            rank(a.kind)
-                .cmp(&rank(b.kind))
-                .then_with(|| a.name.to_lowercase().cmp(&b.name.to_lowercase()))
-        });
+        match self.media_sort {
+            0 => { /* Added - no sorting, keep import order */ }
+            1 => visible.sort_by(|a, b| a.name.to_lowercase().cmp(&b.name.to_lowercase())),
+            2 => visible.sort_by(|a, b| {
+                let rank = |kind: model::MediaKind| match kind {
+                    model::MediaKind::Video => 0,
+                    model::MediaKind::Audio => 1,
+                    model::MediaKind::Image => 2,
+                };
+                rank(a.kind)
+                    .cmp(&rank(b.kind))
+                    .then_with(|| a.name.to_lowercase().cmp(&b.name.to_lowercase()))
+            }),
+            _ => {}
+        }
 
         sync(
             &models.media,
@@ -6877,6 +6889,10 @@ impl Studio {
             2 => vec![
                 row("zoom-in", t("Zoom in"), Glyph::Plus, "+", true),
                 row("zoom-out", t("Zoom out"), Glyph::Minus, "-", true),
+                rule(),
+                check("sort-added", "Sort by: Added", self.media_sort == 0),
+                check("sort-name", "Sort by: Name", self.media_sort == 1),
+                check("sort-kind", "Sort by: Type", self.media_sort == 2),
                 rule(),
                 row("start", t("Go to start"), Glyph::SkipBack, "Home", true),
                 row("end", t("Go to end"), Glyph::SkipForward, "End", true),

--- a/engine/crates/concat/src/studio.rs
+++ b/engine/crates/concat/src/studio.rs
@@ -6799,6 +6799,17 @@ impl Studio {
             kind: MenuRow::Separator,
             ..Default::default()
         };
+        let check = |id: &str, label: &str, on: bool| MenuItemData {
+            id: id.into(),
+            label: label.into(),
+            kind: MenuRow::Action,
+            glyph: Glyph::None,
+            shortcut: "".into(),
+            enabled: true,
+            danger: false,
+            checkable: true,
+            checked: on,
+        };
         let selected = self.selection.len();
         let playhead = f64::from(self.playhead);
         let straddled = self.timeline().clips.iter().any(|clip| {

--- a/engine/crates/concat/src/studio.rs
+++ b/engine/crates/concat/src/studio.rs
@@ -6361,11 +6361,28 @@ impl Studio {
         // The bin.
         let filter = self.media_filter;
         let items = &self.project().media;
+
+        // Grupiši po tipu (Video -> Audio -> Slike), pa abecedno po imenu
+        let mut visible: Vec<_> = items
+            .iter()
+            .filter(|item| Self::shows(filter, item.kind))
+            .collect();
+
+        visible.sort_by(|a, b| {
+            let rank = |kind: model::MediaKind| match kind {
+                model::MediaKind::Video => 0,
+                model::MediaKind::Audio => 1,
+                model::MediaKind::Image => 2,
+            };
+            rank(a.kind)
+                .cmp(&rank(b.kind))
+                .then_with(|| a.name.to_lowercase().cmp(&b.name.to_lowercase()))
+        });
+
         sync(
             &models.media,
-            items
-                .iter()
-                .filter(|item| Self::shows(filter, item.kind))
+            visible
+                .into_iter()
                 .map(|item| MediaItemData {
                     id: *self.media_rows.get(&item.id).unwrap_or(&0),
                     name: item.name.as_str().into(),

--- a/engine/crates/concat/ui/editor.slint
+++ b/engine/crates/concat/ui/editor.slint
@@ -75,6 +75,7 @@ export global Editor {
 
     callback import-media();
     callback media-filter-changed(filter: MediaFilter);
+    callback media-sort-changed(index: int);
     callback media-select(id: int, additive: bool);
     /// A marquee closed over the bin's grid, as the block of cells it caught.
     /// See MediaGrid.band-selected: the grid is placed by arithmetic, so the

--- a/engine/crates/concat/ui/workspace/media-pane.slint
+++ b/engine/crates/concat/ui/workspace/media-pane.slint
@@ -9,6 +9,7 @@ import { PaneKind, PaneSwitcher } from "pane-switcher.slint";
 import { TextAlignment } from "../timeline/model.slint";
 import { CatalogueEntryData, Library } from "../inspector/clip-inspector.slint";
 import { SearchField } from "../inspector/controls.slint";
+import { Select } from "../primitives/select.slint";
 
 // The library pane: a strip of pages across the top, then a narrow category
 // sidebar and the browsing area beside it. Media is the bin; Text adds a
@@ -1245,6 +1246,8 @@ export component MediaPane inherits Rectangle {
 
     callback import-media();
     callback filter-changed(filter: MediaFilter);
+    /// The sort dropdown beside the import button picked a new order.
+    callback sort-changed(index: int);
     /// A press on the bin's floor; see Editor.blur.
     callback floor-pressed();
     callback select(id: int, additive: bool);
@@ -1730,9 +1733,35 @@ export component MediaPane inherits Rectangle {
 
                 if root.tab == 0: HorizontalLayout {
                     padding: 8px;
+                    spacing: 8px;
                     ImportButton {
+                        horizontal-stretch: 1;
                         busy: root.importing;
                         clicked => { root.import-media(); }
+                    }
+                    // Sort and filter live beside the import button, the way
+                    // the owner sketched it; the sidebar rows and the View
+                    // menu drive the same state underneath.
+                    Select {
+                        horizontal-stretch: 0;
+                        width: 130px;
+                        options: [I18n.t("Sort: Added"), I18n.t("Sort: Name"),
+                            I18n.t("Sort: Type")];
+                        current: 0;
+                        changed(index) => { root.sort-changed(index); }
+                    }
+                    Select {
+                        horizontal-stretch: 0;
+                        width: 120px;
+                        options: [I18n.t("All media"), I18n.t("Video"),
+                            I18n.t("Audio"), I18n.t("Images")];
+                        current: 0;
+                        changed(index) => {
+                            root.filter-changed(index == 0 ? MediaFilter.all
+                                : index == 1 ? MediaFilter.video
+                                : index == 2 ? MediaFilter.audio
+                                : MediaFilter.images);
+                        }
                     }
                 }
 

--- a/engine/crates/concat/ui/workspace/seat.slint
+++ b/engine/crates/concat/ui/workspace/seat.slint
@@ -102,6 +102,7 @@ export component Seat inherits Rectangle {
 
             import-media => { Editor.import-media(); }
             filter-changed(filter) => { Editor.media-filter-changed(filter); }
+            sort-changed(index) => { Editor.media-sort-changed(index); }
             floor-pressed => { Editor.blur(); }
             select(id, additive) => {
                 Editor.blur();


### PR DESCRIPTION
## feat: media bin sorting — View menu, auto-grouping, header dropdowns

### What
- View menu gains **Sort by Added / Name / Type** with checkmarks.
- The media bin auto-groups by kind (video, audio, images) and sorts
  within each group, so a large bin reads in a predictable order.
- Sort and Filter dropdowns sit beside the Import Media button in the
  Media tab header; the sidebar rows and the View menu drive the same
  state underneath.

### Why
Bins are insertion-ordered today; with 100+ clips finding anything
means scrolling. Kind-then-name matches how editors think about a
bin, and the dropdowns put the control one click away.

### Changes
- `studio.rs` — sort state and publishing the sorted bin
- `lib.rs` — menu handlers and dropdown callback wiring
- `media-pane.slint` — dropdowns beside the Import button
- menu bar — View menu sort items

### Testing
1. Import mixed clips (video, audio, images).
2. View menu: switch Added / Name / Type — bin reorders, checkmark
   follows the active mode.
3. Header dropdowns: same three orders, plus filter
   All / Video / Audio / Images.
4. Sidebar rows still filter; all three controls stay consistent.
